### PR TITLE
add token to build step

### DIFF
--- a/actions/hybrid_branch_deploy/action.yml
+++ b/actions/hybrid_branch_deploy/action.yml
@@ -14,6 +14,9 @@ inputs:
     required: false
     description: "Whether to start the action by checking out the repository. Set to false if your workflow modifies the file structure before deploying."
     default: 'true'
+  metronome_pat:
+    required: false
+    description: "A GitHub personal access token with the `repo` scope to use for metronome"
   # Build, push, deploy each location
 runs:
   using: "composite"
@@ -66,6 +69,8 @@ runs:
           branch=${{ github.head_ref }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
+      env:
+        METRONOME_PAT: ${{ inputs.metronome_pat }}
 
     - name: Deploy to Dagster Cloud
       uses: ./action-repo/actions/utils/deploy

--- a/actions/hybrid_branch_deploy/action.yml
+++ b/actions/hybrid_branch_deploy/action.yml
@@ -14,7 +14,7 @@ inputs:
     required: false
     description: "Whether to start the action by checking out the repository. Set to false if your workflow modifies the file structure before deploying."
     default: 'true'
-  metronome_pat:
+  metronome_access_token:
     required: false
     description: "A GitHub personal access token with the `repo` scope to use for metronome"
   # Build, push, deploy each location
@@ -70,7 +70,7 @@ runs:
         cache-from: type=gha
         cache-to: type=gha,mode=max
       env:
-        METRONOME_PAT: ${{ inputs.metronome_pat }}
+        METRONOME_ACCESS_TOKEN: ${{ inputs.metronome_access_token }}
 
     - name: Deploy to Dagster Cloud
       uses: ./action-repo/actions/utils/deploy

--- a/actions/hybrid_prod_deploy/action.yml
+++ b/actions/hybrid_prod_deploy/action.yml
@@ -7,6 +7,9 @@ inputs:
   dagster_cloud_api_token:
     description: "Dagster Cloud API token"
     required: true
+  metronome_pat:
+    required: false
+    description: "A GitHub personal access token with the `repo` scope to use for metronome"
   location:
     required: true
     description: 'The code location to deploy. A JSON string consisting of keys "name", "directory", "registry", "location_file".'
@@ -58,6 +61,8 @@ runs:
           branch=${{ github.head_ref }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
+      env:
+        METRONOME_PAT: ${{ inputs.metronome_pat }}
 
     - name: Deploy to Dagster Cloud
       uses: ./action-repo/actions/utils/deploy

--- a/actions/hybrid_prod_deploy/action.yml
+++ b/actions/hybrid_prod_deploy/action.yml
@@ -7,7 +7,7 @@ inputs:
   dagster_cloud_api_token:
     description: "Dagster Cloud API token"
     required: true
-  metronome_pat:
+  metronome_access_token:
     required: false
     description: "A GitHub personal access token with the `repo` scope to use for metronome"
   location:
@@ -62,7 +62,7 @@ runs:
         cache-from: type=gha
         cache-to: type=gha,mode=max
       env:
-        METRONOME_PAT: ${{ inputs.metronome_pat }}
+        METRONOME_ACCESS_TOKEN: ${{ inputs.metronome_access_token }}
 
     - name: Deploy to Dagster Cloud
       uses: ./action-repo/actions/utils/deploy


### PR DESCRIPTION
adds an input for a personal access token, which allows the Dockerfile to use it as an env var to pip install the metronome python client from the private repo